### PR TITLE
SecurityFilterChain에 인증 및 인가 예외를 처리하는 핸들러를 추가하고 인증 예외에 대한 응답을 401으로 응답하도록 변경한다.

### DIFF
--- a/src/main/java/com/gazi/gazi_renew/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/gazi/gazi_renew/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,49 @@
+package com.gazi.gazi_renew.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gazi.gazi_renew.dto.Response;
+import com.gazi.gazi_renew.dto.Response.Body;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final HttpStatus STATUS = FORBIDDEN;
+
+    private final Response responseBuilder;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        Body body = responseBuilder.fail(
+                        "접근 권한이 없습니다.",
+                        STATUS
+                )
+                .getBody();
+
+        response.setContentType(APPLICATION_JSON_VALUE);
+
+        response.setCharacterEncoding("UTF-8");
+
+        response.setStatus(STATUS.value());
+
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(body));
+    }
+
+}

--- a/src/main/java/com/gazi/gazi_renew/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/gazi/gazi_renew/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,49 @@
+package com.gazi.gazi_renew.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gazi.gazi_renew.dto.Response;
+import com.gazi.gazi_renew.dto.Response.Body;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final HttpStatus STATUS = UNAUTHORIZED;
+
+    private final Response responseBuilder;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        Body body = responseBuilder.fail(
+                        "로그인이 유효하지 않습니다.",
+                        STATUS
+                )
+                .getBody();
+
+        response.setContentType(APPLICATION_JSON_VALUE);
+
+        response.setCharacterEncoding("UTF-8");
+
+        response.setStatus(STATUS.value());
+
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(body));
+    }
+
+}

--- a/src/main/java/com/gazi/gazi_renew/config/SecurityConfig.java
+++ b/src/main/java/com/gazi/gazi_renew/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.gazi.gazi_renew.config;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gazi.gazi_renew.dto.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,6 +29,8 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate redisTemplate;
+    private final Response response;
+    private final ObjectMapper objectMapper;
 
 
     CorsConfigurationSource corsConfigurationSource() {
@@ -56,6 +60,21 @@ public class SecurityConfig {
                                 .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(
+                        exception ->
+                                exception.authenticationEntryPoint(
+                                                new CustomAuthenticationEntryPoint(
+                                                        response,
+                                                        objectMapper
+                                                )
+                                        )
+                                        .accessDeniedHandler(
+                                                new CustomAccessDeniedHandler(
+                                                        response,
+                                                        objectMapper
+                                                )
+                                        )
+                )
                 .build();
     }
 


### PR DESCRIPTION
### 현재 동작
서버에서 발생하는 인증 실패 응답은 403으로 응답한다.

### 기대하는 동작
서버에서 발생하는 인증 실패 응답은 401으로 응답한다.

### 수정 내용
Spring Security에서 기본으로 사용하는 핸들러(Http403ForbiddenEntryPoint, AccessDeniedHandlerImpl) 대신 커스텀 구현체를 만들어서 사용합니다.
- 인증 예외 핸들러를 Http403ForbiddenEntryPoint가 아닌 커스텀 구현체를 사용해서 403이 아닌 401을 응답하도록 변경되었음.
- 인가 예외 핸들러를 AccessDeniedHandlerImpl가 아닌 커스텀 구현체를 사용해서 응답하도록 변경되었음.
- 기존 예외에 대한 에러 응답은 가지에서 사용하는 공통 응답 메시지 포맷과 다른 형태로 응답되고 있어 변경되었음. (@Do-youngKim 이 부분은 의도적으로 차이를 둔 것인지 파악이 안되었고 에러 응답 스펙을 변경했을 때 프론트에 영향이 있을지 확인해볼 필요가 있을 것 같아요.)

AS-IS(기존 에러 응답 예시)
```json
{
  "timestamp": "2024-06-23T03:31:15.668+00:00",
  "status": 403,
  "error": "Forbidden",
  "path": "/api/v1/recentSearch"
}
```

TO-BE(가지 공통 응답 메시지에 맞게 변경된 예시)
```json
{
  "state": 401,
  "result": "fail",
  "message": "로그인이 유효하지 않습니다.",
  "data": [],
  "error": []
}
```

