### PR TITLE
feat ; DLT 추가

### DIFF
--- a/src/main/java/com/gazi/gazi_renew/issue/service/kafka/DltNotificationReceiver.java
+++ b/src/main/java/com/gazi/gazi_renew/issue/service/kafka/DltNotificationReceiver.java
@@ -1,0 +1,72 @@
+package com.gazi.gazi_renew.issue.service.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gazi.gazi_renew.notification.domain.dto.NotificationCreate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DltNotificationReceiver {
+
+    private final RestTemplate restTemplate; // Slack 알림용
+    private final ObjectMapper objectMapper; // JSON 인코딩용
+    @Value("${slack.web-hook-url}")
+    private String SLACK_WEBHOOK_URL;
+
+
+    @KafkaListener(topics = "notification.dlt", groupId = "gazi", containerFactory = "notificationListenerContainerFactory") // DLT 토픽 리스너
+    public void handleDltMessage(NotificationCreate notificationCreate) {
+        try {
+            log.error("DLT로 이동된 메시지: {}", notificationCreate);
+
+            // Slack 알림 전송
+            sendSlackNotification(notificationCreate);
+        } catch (Exception e) {
+            log.error("DLT 메시지 처리 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+
+    private void sendSlackNotification(NotificationCreate notificationCreate) {
+        try {
+            // NotificationCreate 객체를 JSON 문자열로 변환
+            String notificationJson = objectMapper.writeValueAsString(notificationCreate);
+
+            // Slack 메시지 내용 생성
+            String slackMessage = String.format(
+                    "⚠️ DLT Message Detected ⚠️\n" +
+                            "Details: ```%s```\n" +
+                            "Please check the issue."
+                    , notificationJson);
+
+            // Slack Webhook으로 메시지 전송
+            String payload = objectMapper.writeValueAsString(new SlackPayload(slackMessage));
+            restTemplate.postForObject(SLACK_WEBHOOK_URL, payload, String.class);
+
+            log.info("Slack 알림 전송 완료: {}", slackMessage);
+        } catch (JsonProcessingException e) {
+            log.error("Slack 메시지 생성 중 JSON 처리 오류: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Slack 알림 전송 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    // Slack Webhook Payload 클래스
+    private static class SlackPayload {
+        private final String text;
+
+        public SlackPayload(String text) {
+            this.text = text;
+        }
+
+        public String getText() {
+            return text;
+        }
+    }
+}

--- a/src/main/java/com/gazi/gazi_renew/issue/service/kafka/NotificationReceiver.java
+++ b/src/main/java/com/gazi/gazi_renew/issue/service/kafka/NotificationReceiver.java
@@ -6,6 +6,9 @@ import com.gazi.gazi_renew.notification.domain.dto.NotificationCreate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.DltStrategy;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -15,7 +18,12 @@ import java.io.IOException;
 public class NotificationReceiver {
 
     private final FcmService fcmService;
-
+    @RetryableTopic(
+            attempts = "3", // 3번 재시도
+            backoff = @Backoff(delay = 5000, multiplier = 2.0), // 재시도 간격 증가
+            dltStrategy = DltStrategy.FAIL_ON_ERROR, // 재시도 실패 후 DLQ로 이동
+            dltTopicSuffix = ".dlt"
+    )
     @KafkaListener(topics = "notification", groupId = "gazi", containerFactory = "notificationListenerContainerFactory")
     public void listener(NotificationCreate notificationCreate) throws IOException {
         log.info("kafka consumer 데이터 받음");

--- a/src/main/java/com/gazi/gazi_renew/notification/service/FcmServiceImpl.java
+++ b/src/main/java/com/gazi/gazi_renew/notification/service/FcmServiceImpl.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class FcmServiceImpl implements FcmService {
     private final IssueRepository issueRepository;
@@ -71,7 +72,6 @@ public class FcmServiceImpl implements FcmService {
     private String API_URL;
 
     @Override
-    @Transactional
     public List<FcmMessage> sendMessageTo(NotificationCreate notificationCreate) throws IOException {
         // FCM 메시지를 리스트로 받음 (각 호선에 대해 개별 메시지 생성)
         List<FcmMessage> messages = makeFcmDto(notificationCreate);


### PR DESCRIPTION
- 크론잡 제거 및 Kafka 도입을 통한 FCM 알림 시스템 최적화: Redis 조회 1,440회 → 2–3회로 감소, DLT 활용으로 장애 복원력 강화 (+slack 연동)